### PR TITLE
[Bugfix] missing value for SelectedLanguages

### DIFF
--- a/Classes/Service/Database.php
+++ b/Classes/Service/Database.php
@@ -271,7 +271,7 @@ class Database {
 				'tstamp' => time(),
 				'crdate' => time(),
 				'be_users_uid' => $BeUserId,
-				'SelectedLanguages' => '',
+				'SelectedLanguages' => '0',
 			)
 		);
 

--- a/Classes/Service/Database.php
+++ b/Classes/Service/Database.php
@@ -270,7 +270,8 @@ class Database {
 			array(
 				'tstamp' => time(),
 				'crdate' => time(),
-				'be_users_uid' => $BeUserId
+				'be_users_uid' => $BeUserId,
+				'SelectedLanguages' => '',
 			)
 		);
 


### PR DESCRIPTION
Got an exception in BE by first call of the backend module.

`array(4 items)
   caller => 'TYPO3\CMS\Core\Database\DatabaseConnection::exec_INSERTquery' (60 chars)
   ERROR => 'Field 'SelectedLanguages' doesn't have a default value' (54 chars)
   lastBuiltQuery => 'INSERT INTO tx_snowbabel_users (tstamp,crdate,be_users_uid) VALUES ('1497249
      237','1497249237','1')' (98 chars)
   debug_backtrace => 'require(Packages/Libraries/typo3/cms/typo3/sysext/backend/Resources/Private/
      Php/backend.php),Packages/Libraries/typo3/cms/typo3/index.php#8 // {closure}
      #25 // TYPO3\CMS\Backend\Http\Application->run#24 // TYPO3\CMS\Core\Core\Boo
      tstrap->handleRequest#92 // TYPO3\CMS\Backend\Http\AjaxRequestHandler->handl
      eRequest#310 // TYPO3\CMS\Backend\Http\AjaxRequestHandler->dispatch#84 // TY
      PO3\CMS\Backend\Http\RouteDispatcher->dispatch#166 // call_user_func_array#5
      4 // TYPO3\CMS\Core\ExtDirect\ExtDirectRouter->routeAction# // TYPO3\CMS\Cor
      e\ExtDirect\ExtDirectRouter->processRpc#87 // call_user_func_array#140 // Sn
      owflake\Snowbabel\Connection\ExtDirectServer->getExtensionMenu# // Snowflake
      \Snowbabel\Connection\ExtDirectServer->getConfigurationObject#86 // TYPO3\CM
      S\Core\Utility\GeneralUtility::makeInstance#397 // Snowflake\Snowbabel\Servi
      ce\Configuration->__construct#3944 // Snowflake\Snowbabel\Service\Configurat
      ion->loadConfiguration#115 // Snowflake\Snowbabel\Service\Configuration->loa
      dUserConfiguration#625 // Snowflake\Snowbabel\Service\Database->getUserConfC
      heck#773 // Snowflake\Snowbabel\Service\Database->insertUserConfCheck#167 //
       TYPO3\CMS\Core\Database\DatabaseConnection->exec_INSERTquery#273 // TYPO3\C
      MS\Core\Database\DatabaseConnection->debug#218' (1262 chars)`